### PR TITLE
hex digits in regexs generate properly

### DIFF
--- a/src/regexp.js
+++ b/src/regexp.js
@@ -69,7 +69,7 @@ const fuzzPrintableAscii = f => {
   return String.fromCharCode(32 + f.rng.nextInt(94));
 }
 
-const fuzzHex = oneOf(['0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f','A','B','C','D','E','F']);
+const fuzzHex = oneOf('0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f','A','B','C','D','E','F');
 
 
 const fuzzAlternation = f => {


### PR DESCRIPTION
Sigh.

(This was introduced late, in a change for node 0.12 compatibility.)

The website should be updated also.
