### PR TITLE
fixes #15: don't shim Array.from (drops node 0.12 support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ script:
   - npm run build
   - npm test
 node_js:
-  - "0.12"
   - "4"
   - "6"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "prepublish": "rm -rf dist/* && npm update && npm run build"
   },
   "dependencies": {
-    "array.from": "^1.0.1",
     "shift-ast": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "esutils": "2.0.2",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.4",
-    "shift-codegen": "^5.0.0",
-    "shift-parser": "^5.0.0",
-    "shift-validator": "^3.0.0"
+    "shift-codegen": "5.0.0",
+    "shift-parser": "5.0.0",
+    "shift-validator": "3.0.0"
   },
   "keywords": [
     "Shift",

--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,6 @@ import { ap, choose, guardDepth, many, many1, manyN, oneOf, opt, MANY_BOUND } fr
 import fuzzRegExpPattern from "./regexp";
 
 
-require('array.from').shim(); // node 0.12 hack.
-
 const RESERVED =  [ // todo import this
   // keywords
   'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger',


### PR DESCRIPTION
Fixes #15. I expect this to fail CI because we have a loose dependency on shift-parser-js and it's had some bug fixes which will recognise some invalid programs created by the fuzzer. I'm not going to fix those right now.