### PR TITLE
Prohibit enum as an identifier even in sloppy mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   },
   "devDependencies": {
     "babel-cli": "6.3.13",
-    "babel-register": "6.3.13",
     "babel-preset-es2015": "6.3.13",
+    "babel-register": "6.3.13",
     "esutils": "2.0.2",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.4",
-    "shift-codegen": "5.0.0",
-    "shift-parser": "5.0.0",
+    "shift-codegen": "5.0.3",
+    "shift-parser": "5.0.6",
     "shift-validator": "3.0.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "esutils": "2.0.2",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.4",
-    "shift-codegen": "5.0.3",
-    "shift-parser": "5.0.6",
+    "shift-codegen": "5.0.4",
+    "shift-parser": "5.0.7",
     "shift-validator": "3.0.0"
   },
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -31,11 +31,13 @@ const RESERVED =  [ // todo import this
   'with',
   // null, booleans
   'null', 'true', 'false',
+  // future reserved word
+  'enum',
 ];
 
 const STRICT_FORBIDDEN = [
   'implements', 'package', 'protected', 'interface', 'private', 'public',
-  'static', 'enum'
+  'static'
 ];
 
 const ALL_KNOWN_WORDS = RESERVED.concat(STRICT_FORBIDDEN).concat(['let', 'yield', 'await', 'eval', 'arguments', 'constructor', 'prototype']);


### PR DESCRIPTION
Also updates dependencies so that tests pass.