### PR TITLE
ES2018 implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "expect.js": "^0.3.1",
     "mocha": "^2.3.4",
     "shift-codegen": "6.0.0",
-    "shift-parser": "6.0.0",
+    "shift-parser": "6.0.1",
     "shift-validator": "4.0.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "esutils": "2.0.2",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.4",
-    "shift-codegen": "^7.0.2",
+    "shift-codegen": "^7.0.3",
     "shift-parser": "^7.0.3",
     "shift-validator": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepublish": "rm -rf dist/* && npm update && npm run build"
   },
   "dependencies": {
-    "shift-ast": "^4.0.0"
+    "shift-ast": "5.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.3.13",
@@ -27,9 +27,9 @@
     "esutils": "2.0.2",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.4",
-    "shift-codegen": "5.0.4",
-    "shift-parser": "5.0.7",
-    "shift-validator": "3.0.0"
+    "shift-codegen": "6.0.0",
+    "shift-parser": "6.0.0",
+    "shift-validator": "4.0.0"
   },
   "keywords": [
     "Shift",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mocha": "^2.3.4",
     "shift-codegen": "^7.0.3",
     "shift-parser": "^7.0.3",
-    "shift-validator": "^5.0.0"
+    "shift-validator": "^5.0.1"
   },
   "keywords": [
     "Shift",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepublish": "rm -rf dist/* && npm update && npm run build"
   },
   "dependencies": {
-    "shift-ast": "5.0.0"
+    "shift-ast": "6.1.0"
   },
   "devDependencies": {
     "babel-cli": "6.3.13",
@@ -27,9 +27,9 @@
     "esutils": "2.0.2",
     "expect.js": "^0.3.1",
     "mocha": "^2.3.4",
-    "shift-codegen": "6.0.0",
-    "shift-parser": "6.0.1",
-    "shift-validator": "4.0.0"
+    "shift-codegen": "^7.0.2",
+    "shift-parser": "^7.0.3",
+    "shift-validator": "^5.0.0"
   },
   "keywords": [
     "Shift",

--- a/src/index.js
+++ b/src/index.js
@@ -121,8 +121,9 @@ const toRawValue = (f, str) => {
     // }`);
     // str = str.replace(/((^|[^\\])(\\\\)*\\)x/g, `$1x${fuzzHexDigit(f)}${fuzzHexDigit(f)}`); // todo consider inserting escape sequences like \u{XXXXX} etc into strings. This technique works, but not in combination with our hack for dealing with the \u\u case.
     if (f.strict) {
-      str = str.replace(/((^|[^\\])(\\\\)*\\)0([0-7])/g, `$1\\0$4`);
-      str = str.replace(/((^|[^\\])(\\\\)*\\)([1-7])/g, `$1\\$4`);
+      str = str.replace(/((^|[^\\])(\\\\)*\\)0([0-9])/g, `$1\\0$4`);
+      // this should be changed to 1-7 if https://github.com/tc39/ecma262/pull/2054 lands
+      str = str.replace(/((^|[^\\])(\\\\)*\\)([1-9])/g, `$1\\$4`);
     }
   } while(str !== orig); // loop is to handle e.g. \8\8, because javascript lacks lookbehind and faking it is painful.
   return str;
@@ -362,7 +363,7 @@ export const fuzzFormalParameters = (f = new FuzzerState, {hasStrictDirective = 
 }
 
 export const fuzzFunctionBody = f =>
-  ap(Shift.FunctionBody, {"directives": many(fuzzDirective), "statements": many(fuzzStatement)}, f);
+  ap(Shift.FunctionBody, {"directives": fuzzDirectives(f).directives, "statements": many(fuzzStatement)}, f);
 
 export const fuzzFunctionDeclaration = (f = new FuzzerState, {allowProperDeclarations = true} = {}) => {
   let {directives, hasStrictDirective} = fuzzDirectives(f);


### PR DESCRIPTION
Subsumes https://github.com/shapesecurity/shift-fuzzer-js/pull/26, which was blocked on fixing a bunch of upstream bugs which have now been fixed in the 2018 implementations and which I am too lazy to backport.